### PR TITLE
Gemspec: Drop EOL'd rubyforge_project directive

### DIFF
--- a/pressar.gemspec
+++ b/pressar.gemspec
@@ -12,8 +12,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Billy Fowks"]
   s.email       = 'bf@billyfowks.com'
   s.homepage    =
-    'http://rubygems.org/gems/pressar'
-  s.rubyforge_project = "pressar"
+    'https://rubygems.org/gems/pressar'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.